### PR TITLE
Feat: Brand selector filtering for templates

### DIFF
--- a/app/types/global.ts
+++ b/app/types/global.ts
@@ -21,3 +21,5 @@ export interface TemplateWithTeam extends Template {
 }
 
 export type TeamRole = TeamMember['role'];
+
+export type Brand = Tables['brands']['Row'];

--- a/app/types/supabase.d.ts
+++ b/app/types/supabase.d.ts
@@ -199,6 +199,30 @@ export type Database = {
         };
         Relationships: [];
       };
+      brands: {
+        Row: {
+          id: string;
+          slug: string;
+          name: string;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          slug: string;
+          name: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          slug?: string;
+          name?: string;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
     };
     Views: {
       [_ in never]: never;

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -52,6 +52,8 @@ export default [
         module: 'readonly',
         require: 'readonly',
         exports: 'readonly',
+        URLSearchParams: 'readonly',
+        HTMLSelectElement: 'readonly',
       },
     },
     plugins: {

--- a/supabase/migrations/20251003172411_add_brands_support.sql
+++ b/supabase/migrations/20251003172411_add_brands_support.sql
@@ -1,0 +1,28 @@
+-- =============================================
+-- STEP 1: Create brands table
+-- =============================================
+create table if not exists public.brands (
+  id uuid primary key default uuid_generate_v4(),
+  slug text not null unique,
+  name text not null,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- =============================================
+-- STEP 2: Add brand_id to templates
+-- =============================================
+alter table public.templates
+add column if not exists brand_id uuid references public.brands (id);
+
+-- Index for filtering by brand
+create index if not exists templates_brand_id_idx on public.templates (brand_id);
+
+-- =============================================
+-- STEP 3: Enable RLS + policies for brands
+-- =============================================
+alter table public.brands enable row level security;
+
+-- Anyone authenticated can read brands (needed for filtering dropdowns)
+create policy "Authenticated users can view brands" on public.brands for
+select to authenticated using (true);

--- a/supabase/migrations/20251003203629_create_templates_with_brands_view.sql
+++ b/supabase/migrations/20251003203629_create_templates_with_brands_view.sql
@@ -1,0 +1,18 @@
+-- =============================================
+-- Create view for templates with brand details
+-- =============================================
+create or replace view public.templates_with_brands as
+select
+  t.id,
+  t.title,
+  t.description,
+  t.thumbnail_url,
+  t.team_id,
+  t.creator_user_id,
+  t.created_at,
+  t.updated_at,
+  b.id as brand_id,
+  b.slug as brand_slug,
+  b.name as brand_name
+from public.templates t
+left join public.brands b on t.brand_id = b.id;

--- a/supabase/seed/main.sql
+++ b/supabase/seed/main.sql
@@ -34,3 +34,15 @@ INSERT INTO public.template_locales
   (id, template_id, locale, last_render_url, thumbnail_url, created_at, updated_at)
 VALUES 
   ('660e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440001', 'en', NULL, '/product-launch-thumbnail.png', NOW(), NOW());
+
+-- Brands
+INSERT INTO public.brands (id, slug, name)
+values
+  (uuid_generate_v4(), 'vio-ljusfabrik', 'Vio Ljusfabrik'),
+  (uuid_generate_v4(), 'blendalabs', 'Blenda Labs')
+on conflict (slug) do nothing;
+
+-- Fallback: all unassigned templates go to Default brand
+UPDATE public.templates
+set brand_id = (select id from public.brands where slug = 'vio-ljusfabrik')
+where brand_id is null;


### PR DESCRIPTION
### Changes
- Added migrations to add the brands table + brand_id to templates
- Added `templates_with_brands` view
- Implemented brand filtering feature on UI

### Verification
- Ran migrations and seed successfully (screenshot attached)
- Verified brand filter updates templates list as expected (screenshot attached)
- Ran `npm run fix` — code passes lint and formatting checks

<img width="1680" height="819" alt="Screenshot 2025-10-04 at 1 27 45 PM" src="https://github.com/user-attachments/assets/4cf0e3da-b284-4138-afc6-44e52e78486e" />

<img width="683" height="224" alt="Screenshot 2025-10-04 at 1 28 01 PM" src="https://github.com/user-attachments/assets/f0214c15-df76-4e5d-841a-a5be9e30e625" />
