### PR TITLE
Add brand filtering feature for video templates

### DIFF
--- a/app/components/BrandFilter.tsx
+++ b/app/components/BrandFilter.tsx
@@ -1,0 +1,77 @@
+/* eslint-disable react/prop-types */
+import { useSearchParams } from 'react-router';
+import { Check, Tag } from 'lucide-react';
+
+import { Button } from '~/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '~/components/ui/dropdown-menu';
+
+import type { Brand } from '~/types/global';
+
+interface BrandFilterProps {
+  brands: Brand[];
+}
+const UNASSIGNED_FILTER = 'unassigned';
+
+/**
+ * Dropdown for selecting brands to filter templates.
+ * Supports three states: All brands, Unassigned (no brand), or specific brand.
+ * Updates URL search params to trigger filtering.
+ */
+export const BrandFilter: React.FC<BrandFilterProps> = ({ brands }) => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const currentBrand = searchParams.get('brand');
+
+  // Set button text based on filter state
+  const selectedBrandName = brands.find(b => b.slug === currentBrand)?.name;
+  const displayText =
+    currentBrand === UNASSIGNED_FILTER
+      ? 'Unassigned'
+      : selectedBrandName || 'All Brands';
+
+  const handleBrandSelect = (brandSlug: string | null) => {
+    if (brandSlug == null) {
+      setSearchParams({});
+    } else {
+      setSearchParams({ brand: brandSlug });
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm" className="gap-2">
+          <Tag className="h-4 w-4" />
+          {displayText}
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-48">
+        <DropdownMenuItem onSelect={() => handleBrandSelect(null)}>
+          All Brands
+          {!currentBrand && <Check className="h-4 w-4 mr-2" />}
+        </DropdownMenuItem>
+        <DropdownMenuItem onSelect={() => handleBrandSelect(UNASSIGNED_FILTER)}>
+          Unassigned
+          {currentBrand === UNASSIGNED_FILTER && (
+            <Check className="h-4 w-4 mr-2" />
+          )}
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {brands.map(brand => (
+          <DropdownMenuItem
+            key={brand.id}
+            onSelect={() => handleBrandSelect(brand.slug)}
+          >
+            {brand.name}
+            {currentBrand === brand.slug && <Check className="h-4 w-4 mr-2" />}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+};

--- a/app/components/ui/dropdown-menu.tsx
+++ b/app/components/ui/dropdown-menu.tsx
@@ -1,0 +1,134 @@
+import * as React from 'react';
+import * as DropdownMenuPrimitive from '@radix-ui/react-dropdown-menu';
+import { CircleIcon } from 'lucide-react';
+
+import { cn } from '~/lib/utils';
+
+function DropdownMenu({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Root>) {
+  return <DropdownMenuPrimitive.Root data-slot="dropdown-menu" {...props} />;
+}
+
+function DropdownMenuTrigger({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Trigger>) {
+  return (
+    <DropdownMenuPrimitive.Trigger
+      data-slot="dropdown-menu-trigger"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Group>) {
+  return (
+    <DropdownMenuPrimitive.Group data-slot="dropdown-menu-group" {...props} />
+  );
+}
+
+function DropdownMenuPortal({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Portal>) {
+  return (
+    <DropdownMenuPrimitive.Portal data-slot="dropdown-menu-portal" {...props} />
+  );
+}
+
+function DropdownMenuRadioGroup({
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioGroup>) {
+  return (
+    <DropdownMenuPrimitive.RadioGroup
+      data-slot="dropdown-menu-radio-group"
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuContent({
+  className,
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Content>) {
+  return (
+    <DropdownMenuPrimitive.Portal>
+      <DropdownMenuPrimitive.Content
+        data-slot="dropdown-menu-content"
+        sideOffset={sideOffset}
+        className={cn(
+          'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-[8rem] overflow-hidden rounded-md border p-1 shadow-md',
+          className
+        )}
+        {...props}
+      />
+    </DropdownMenuPrimitive.Portal>
+  );
+}
+
+function DropdownMenuItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Item>) {
+  return (
+    <DropdownMenuPrimitive.Item
+      data-slot="dropdown-menu-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  );
+}
+
+function DropdownMenuRadioItem({
+  className,
+  children,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.RadioItem>) {
+  return (
+    <DropdownMenuPrimitive.RadioItem
+      data-slot="dropdown-menu-radio-item"
+      className={cn(
+        "focus:bg-accent focus:text-accent-foreground [&_svg:not([class*='text-'])]:text-muted-foreground relative flex cursor-default items-center gap-2 rounded-sm py-1.5 pr-2 pl-8 text-sm outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    >
+      <span className="absolute left-2 flex size-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <CircleIcon className="size-2 fill-current" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.RadioItem>
+  );
+}
+
+function DropdownMenuSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof DropdownMenuPrimitive.Separator>) {
+  return (
+    <DropdownMenuPrimitive.Separator
+      data-slot="dropdown-menu-separator"
+      className={cn('bg-border pointer-events-none -mx-1 my-1 h-px', className)}
+      {...props}
+    />
+  );
+}
+
+export {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuPortal,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+};

--- a/app/routes/_in.$teamSlug.tsx
+++ b/app/routes/_in.$teamSlug.tsx
@@ -25,7 +25,7 @@ export default function InLayout() {
         <TopBar />
 
         {/* Dynamic Content Area */}
-        <main className="flex-1 p-6 overflow-y-auto">
+        <main className="flex-1 px-6 pb-6 overflow-y-auto">
           <Outlet />
         </main>
       </div>

--- a/app/types/global.ts
+++ b/app/types/global.ts
@@ -7,6 +7,7 @@ export type Template = Tables['templates']['Row'];
 export type TemplateLocale = Tables['template_locales']['Row'];
 export type Team = Tables['teams']['Row'];
 export type TeamMember = Tables['team_members']['Row'];
+export type Brand = Tables['brands']['Row'];
 
 export interface TemplateWithLocales extends Template {
   template_locales: TemplateLocale[];

--- a/app/types/supabase.d.ts
+++ b/app/types/supabase.d.ts
@@ -9,6 +9,30 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      brands: {
+        Row: {
+          created_at: string;
+          id: string;
+          name: string;
+          slug: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          name: string;
+          slug: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          name?: string;
+          slug?: string;
+          updated_at?: string;
+        };
+        Relationships: [];
+      };
       team_members: {
         Row: {
           id: string;
@@ -126,6 +150,7 @@ export type Database = {
       };
       templates: {
         Row: {
+          brand_id: string | null;
           created_at: string;
           creator_user_id: string | null;
           description: string | null;
@@ -137,6 +162,7 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
+          brand_id?: string | null;
           created_at?: string;
           creator_user_id?: string | null;
           description?: string | null;
@@ -148,6 +174,7 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
+          brand_id?: string | null;
           created_at?: string;
           creator_user_id?: string | null;
           description?: string | null;
@@ -159,6 +186,13 @@ export type Database = {
           updated_at?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: 'templates_brand_id_fkey';
+            columns: ['brand_id'];
+            isOneToOne: false;
+            referencedRelation: 'brands';
+            referencedColumns: ['id'];
+          },
           {
             foreignKeyName: 'templates_creator_user_id_fkey';
             columns: ['creator_user_id'];

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@radix-ui/react-checkbox": "^1.3.3",
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-hover-card": "^1.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-progress": "^1.1.7",
@@ -1529,6 +1530,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1625,6 +1655,46 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "dependencies": {
     "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-hover-card": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-progress": "^1.1.7",

--- a/supabase/migrations/20251004091102_add_brands_table.sql
+++ b/supabase/migrations/20251004091102_add_brands_table.sql
@@ -1,0 +1,50 @@
+-- Migration: Add brands table and link to templates
+-- for filtering (e.g., ?brand=vio-ljusfabrik)
+
+-- Create the brands table
+-- I have presumed that Brands are simple labels/categories for organizing templates
+CREATE TABLE IF NOT EXISTS brands (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name TEXT NOT NULL,
+  slug TEXT NOT NULL UNIQUE,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Add brand_id column to templates table
+-- This is nullable (optional) so templates can exist without being assigned to a brand
+ALTER TABLE templates
+  ADD COLUMN brand_id UUID REFERENCES brands(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_templates_brand_id ON templates(brand_id);
+
+-- Enable Row Level Security on brands table
+ALTER TABLE brands ENABLE ROW LEVEL SECURITY;
+
+-- Brands Policies
+-- Note: Brands are global resources, not team-scoped
+create policy "Authenticated users can view brands"
+  on public.brands for select
+  to authenticated
+  using (true);
+
+create policy "Authenticated users can insert brands"
+  on public.brands for insert
+  to authenticated
+  with check (true);
+
+create policy "Authenticated users can update brands"
+  on public.brands for update
+  to authenticated
+  using (true);
+
+create policy "Authenticated users can delete brands"
+  on public.brands for delete
+  to authenticated
+  using (true);
+
+-- Create trigger for automatic updated_at
+create trigger set_updated_at
+  before update on public.brands
+  for each row
+  execute function public.handle_updated_at();

--- a/supabase/seed/main.sql
+++ b/supabase/seed/main.sql
@@ -23,14 +23,29 @@ INSERT INTO public.team_members
 VALUES
   (E'6f55fdd4-ef6e-4ff2-95f5-1db8e8cb2815', E'5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', E'813b6b64-f5f4-49ea-9719-c49db026d937', E'admin', E'2025-09-18 11:25:01.685084+00');
 
+  -- Brands
+  INSERT INTO public.brands
+    (id, name, slug, created_at, updated_at)
+  VALUES
+    ('880e8400-e29b-41d4-a716-446655440001', 'Nike Shoes', 'nike-shoes', NOW(), NOW()),
+    ('990e8400-e29b-41d4-a716-446655440001', 'Adidas Shoes', 'adidas-shoes', NOW(), NOW()),
+    ('aa0e8400-e29b-41d4-a716-446655440001', 'Puma Shoes', 'puma-shoes', NOW(), NOW()),
+    ('bb0e8400-e29b-41d4-a716-446655440001', 'New Balance Shoes', 'new-balance-shoes', NOW(), NOW());
+
 -- Templates
 INSERT INTO public.templates
-  (id, title, description, team_id, creator_user_id, thumbnail_url, duration, created_at, updated_at)
-VALUES 
-  ('550e8400-e29b-41d4-a716-446655440001', 'Video Template 1', 'Example product video', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', '813b6b64-f5f4-49ea-9719-c49db026d937', '/video_placeholder.svg', 12110, NOW(), NOW());
+  (id, title, description, team_id, creator_user_id, thumbnail_url, duration, brand_id, created_at, updated_at)
+VALUES
+  ('550e8400-e29b-41d4-a716-446655440001', 'Video Template 1', 'Example product video', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', '813b6b64-f5f4-49ea-9719-c49db026d937', '/video_placeholder.svg', 12110,'880e8400-e29b-41d4-a716-446655440001',  NOW(), NOW()),
+  ('660e8400-e29b-41d4-a716-446655440002', 'Video Template 2', 'Example product video', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', '813b6b64-f5f4-49ea-9719-c49db026d937', '/video_placeholder.svg', 12110,'880e8400-e29b-41d4-a716-446655440001',  NOW(), NOW()),
+  ('770e8400-e29b-41d4-a716-446655440003', 'Video Template 3', 'Example product video', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', '813b6b64-f5f4-49ea-9719-c49db026d937', '/video_placeholder.svg', 12110,'bb0e8400-e29b-41d4-a716-446655440001',  NOW(), NOW()),
+  ('880e8400-e29b-41d4-a716-446655440004', 'Video Template 4', 'Example product video', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', '813b6b64-f5f4-49ea-9719-c49db026d937', '/video_placeholder.svg', 12110, NULL, NOW(), NOW());
 
 -- template locales
 INSERT INTO public.template_locales
   (id, template_id, locale, last_render_url, thumbnail_url, created_at, updated_at)
-VALUES 
-  ('660e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440001', 'en', NULL, '/product-launch-thumbnail.png', NOW(), NOW());
+VALUES
+  ('660e8400-e29b-41d4-a716-446655440001', '550e8400-e29b-41d4-a716-446655440001', 'en', NULL, '/product-launch-thumbnail.png', NOW(), NOW()),
+  ('660e8400-e29b-41d4-a716-446655440002', '660e8400-e29b-41d4-a716-446655440002', 'se', NULL, '/product-launch-thumbnail.png', NOW(), NOW()),
+  ('660e8400-e29b-41d4-a716-446655440003', '770e8400-e29b-41d4-a716-446655440003', 'fi', NULL, '/product-launch-thumbnail.png', NOW(), NOW()),
+  ('660e8400-e29b-41d4-a716-446655440004', '880e8400-e29b-41d4-a716-446655440004', 'fr', NULL, '/product-launch-thumbnail.png', NOW(), NOW());


### PR DESCRIPTION
## Summary
Adds brand filtering to the video templates page via a dropdown selector and URL param (`?brand=slug`).

## Changes
- **Database:** Added `brands` table with RLS policies, triggers, and seed data  
- **Component:** New `BrandFilter` dropdown (All, Unassigned, Specific Brand)  
- **Filtering:** Conditional INNER/LEFT joins for efficient Supabase queries  
- **UI:** Sticky filter bar and brand label on each template card  
- **Types:** Added `Brand` to `global.ts` and updated Supabase types  
- **Seed:** Added 4 example brands with test templates  

## Features
- Filter templates by brand or show only unassigned templates  
- Selected filter persists via URL param (`?brand=slug`)  
- Visual checkmark on selected option  
- Grey italic label for unassigned templates  

## Technical Notes
- Consistent with project style guide (React.FC, Props interfaces, import order)  
- Fully typed in TypeScript  
- Queries optimized with conditional joins  
- RLS and triggers mirror existing tables