### PR TITLE
Add brand management and brand selector

### DIFF
--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -1,6 +1,6 @@
 import { Link, useParams } from 'react-router';
 import { Button } from '~/components/ui/button';
-import { Video } from 'lucide-react';
+import { Building2, Video } from 'lucide-react';
 import packageJson from '../../../package.json';
 import { useAuth } from '~/lib/auth';
 
@@ -40,6 +40,16 @@ export function Sidebar({ currentPath }: SidebarProps) {
             <Link to={`/${teamSlug}/templates`}>
               <Video className="h-4 w-4" />
               Templates
+            </Link>
+          </Button>
+          <Button
+            variant={isActive('/brands') ? 'default' : 'ghost'}
+            className="w-full justify-start gap-3"
+            asChild
+          >
+            <Link to={`/${teamSlug}/brands`}>
+              <Building2 className="h-4 w-4" />
+              Brands
             </Link>
           </Button>
         </div>

--- a/app/components/navigation/Sidebar.tsx
+++ b/app/components/navigation/Sidebar.tsx
@@ -1,27 +1,92 @@
 import { Link, useParams } from 'react-router';
 import { Button } from '~/components/ui/button';
-import { Building2, Video } from 'lucide-react';
+import { Building2, type LucideIcon, Video } from 'lucide-react';
 import packageJson from '../../../package.json';
 import { useAuth } from '~/lib/auth';
+
+interface NavigationLink {
+  href: string;
+  icon: LucideIcon;
+  label: string;
+  path: string;
+}
 
 interface SidebarProps {
   currentPath: string;
 }
 
-export function Sidebar({ currentPath }: SidebarProps) {
+function getNavigationLinks(teamSlug?: string): NavigationLink[] {
+  return [
+    {
+      href: `/${teamSlug}/templates`,
+      icon: Video,
+      label: 'Templates',
+      path: '/templates',
+    },
+    {
+      href: `/${teamSlug}/brands`,
+      icon: Building2,
+      label: 'Brands',
+      path: '/brands',
+    },
+  ];
+}
+
+function getIsActive(currentPath: string, teamSlug: string | undefined) {
+  return (path: string) => {
+    const pathWithoutTeamSlug = currentPath.replace(`/${teamSlug}`, '');
+    return pathWithoutTeamSlug.startsWith(path);
+  };
+}
+
+export function NavigationLinks({
+  currentPath,
+  onNavigate,
+}: SidebarProps & { onNavigate?: () => void }) {
   const params = useParams();
   const teamSlug = params.teamSlug;
-  const { user } = useAuth();
-
-  const isActive = (path: string) => {
-    // Remove the team slug from the current path for comparison
-    const pathWithoutTeamSlug = currentPath.replace(`/${teamSlug}`, '');
-    if (pathWithoutTeamSlug.startsWith(path)) return true;
-    return false;
-  };
+  const links = getNavigationLinks(teamSlug);
+  const isActive = getIsActive(currentPath, teamSlug);
 
   return (
-    <aside className="w-64 bg-card border-r border-border flex flex-col">
+    <div className="space-y-2">
+      {links.map(link => {
+        const Icon = link.icon;
+
+        return (
+          <Button
+            key={link.path}
+            variant={isActive(link.path) ? 'default' : 'ghost'}
+            className="w-full justify-start gap-3"
+            asChild
+          >
+            <Link to={link.href} onClick={onNavigate}>
+              <Icon className="h-4 w-4" />
+              {link.label}
+            </Link>
+          </Button>
+        );
+      })}
+    </div>
+  );
+}
+
+export function NavigationFooter() {
+  const { user } = useAuth();
+
+  return (
+    <div className="p-4 border-t border-border">
+      <div className="text-xs text-muted-foreground space-y-1">
+        {user?.email && <div className="truncate">{user.email}</div>}
+        <div>v{packageJson.version}</div>
+      </div>
+    </div>
+  );
+}
+
+export function Sidebar({ currentPath }: SidebarProps) {
+  return (
+    <aside className="hidden w-64 bg-card border-r border-border md:flex flex-col">
       <div className="p-6 border-b border-border">
         <img
           src="/blenda_logo_horizontal.svg"
@@ -31,37 +96,11 @@ export function Sidebar({ currentPath }: SidebarProps) {
       </div>
 
       <nav className="flex-1 p-4">
-        <div className="space-y-2">
-          <Button
-            variant={isActive('/templates') ? 'default' : 'ghost'}
-            className="w-full justify-start gap-3"
-            asChild
-          >
-            <Link to={`/${teamSlug}/templates`}>
-              <Video className="h-4 w-4" />
-              Templates
-            </Link>
-          </Button>
-          <Button
-            variant={isActive('/brands') ? 'default' : 'ghost'}
-            className="w-full justify-start gap-3"
-            asChild
-          >
-            <Link to={`/${teamSlug}/brands`}>
-              <Building2 className="h-4 w-4" />
-              Brands
-            </Link>
-          </Button>
-        </div>
+        <NavigationLinks currentPath={currentPath} />
       </nav>
 
       {/* Footer */}
-      <div className="p-4 border-t border-border">
-        <div className="text-xs text-muted-foreground space-y-1">
-          {user?.email && <div className="truncate">{user.email}</div>}
-          <div>v{packageJson.version}</div>
-        </div>
-      </div>
+      <NavigationFooter />
     </aside>
   );
 }

--- a/app/components/navigation/TopBar.tsx
+++ b/app/components/navigation/TopBar.tsx
@@ -1,12 +1,25 @@
 import { useNavigate, useParams } from 'react-router';
 import { Button } from '~/components/ui/button';
-import { Bell, Settings, LogOut } from 'lucide-react';
-import { useEffect } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog';
+import { Bell, LogOut, Menu, Settings } from 'lucide-react';
+import { useEffect, useState } from 'react';
 import { createSupabaseBrowserClient } from '~/services/supabase.client';
+import { NavigationFooter, NavigationLinks } from './Sidebar';
 
-export function TopBar() {
+interface TopBarProps {
+  currentPath: string;
+}
+
+export function TopBar({ currentPath }: TopBarProps) {
   const navigate = useNavigate();
   const params = useParams();
+  const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   // Fetch user's teams
   useEffect(() => {
@@ -54,8 +67,35 @@ export function TopBar() {
   };
 
   return (
-    <header className="h-16 bg-card border-b border-border flex items-center justify-between px-6">
-      <div className="flex items-center gap-4"></div>
+    <header className="h-16 bg-card border-b border-border flex items-center justify-between px-4 md:px-6">
+      <div className="flex min-w-0 items-center gap-3">
+        <Dialog open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
+          <DialogTrigger asChild>
+            <Button variant="ghost" size="icon" className="md:hidden">
+              <Menu className="h-4 w-4" />
+              <span className="sr-only">Open navigation</span>
+            </Button>
+          </DialogTrigger>
+          <DialogContent className="top-0 left-0 flex h-full max-w-72 translate-x-0 translate-y-0 flex-col rounded-none p-0 sm:max-w-80">
+            <DialogHeader>
+              <DialogTitle className="p-6 pb-2">
+                <img
+                  src="/blenda_logo_horizontal.svg"
+                  alt="Blenda Labs"
+                  className="h-9 w-auto"
+                />
+              </DialogTitle>
+            </DialogHeader>
+            <nav className="flex-1 p-4">
+              <NavigationLinks
+                currentPath={currentPath}
+                onNavigate={() => setIsMobileMenuOpen(false)}
+              />
+            </nav>
+            <NavigationFooter />
+          </DialogContent>
+        </Dialog>
+      </div>
 
       <div className="flex items-center gap-3">
         <Button variant="ghost" size="icon">
@@ -70,7 +110,7 @@ export function TopBar() {
           className="gap-2 transition-all duration-200 hover:scale-105"
         >
           <LogOut className="h-4 w-4" />
-          Sign Out
+          <span className="hidden sm:inline">Sign Out</span>
         </Button>
       </div>
     </header>

--- a/app/routes/_in.$teamSlug.brands.tsx
+++ b/app/routes/_in.$teamSlug.brands.tsx
@@ -1,0 +1,385 @@
+import {
+  Form,
+  redirect,
+  useActionData,
+  useLoaderData,
+  useNavigation,
+  type MetaFunction,
+} from 'react-router';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { Building2, ImageIcon, Plus, Save, Trash2 } from 'lucide-react';
+
+import { Button } from '~/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/components/ui/card';
+import { Input } from '~/components/ui/input';
+import { Label } from '~/components/ui/label';
+import { requireAuthWithClient, ensureUserProfile } from '../lib/auth.server';
+import { appService } from '~/services/app';
+import type { Brand, Team } from '~/types/global';
+import type { Database } from '~/types/supabase';
+
+type TypedSupabaseClient = SupabaseClient<Database>;
+
+interface BrandFormValues {
+  name: string;
+  slug: string;
+  logo_url: string | null;
+}
+
+type BrandFormResult =
+  | { ok: true; values: BrandFormValues }
+  | { ok: false; error: string };
+
+export const meta: MetaFunction = () => {
+  return [{ title: `Brands - ${appService.strings.app.title}` }];
+};
+
+function getStringValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeSlug(value: string) {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+}
+
+function getBrandFormValues(formData: FormData): BrandFormResult {
+  const name = getStringValue(formData, 'name');
+  const rawSlug = getStringValue(formData, 'slug');
+  const logoUrl = getStringValue(formData, 'logo_url');
+  const slug = normalizeSlug(rawSlug || name);
+
+  if (!name) {
+    return { ok: false, error: 'Brand name is required.' };
+  }
+
+  if (!slug) {
+    return { ok: false, error: 'Brand slug is required.' };
+  }
+
+  return {
+    ok: true,
+    values: {
+      name,
+      slug,
+      logo_url: logoUrl || null,
+    },
+  };
+}
+
+function getMutationErrorMessage(error: { code?: string; message: string }) {
+  if (error.code === '23505') {
+    return 'A brand with this slug already exists for this team.';
+  }
+
+  return error.message;
+}
+
+async function getTeamForUser(
+  supabaseClient: TypedSupabaseClient,
+  userId: string,
+  teamSlug: string
+) {
+  const { data: team, error: teamError } = await supabaseClient
+    .from('teams')
+    .select('id, name, slug')
+    .eq('slug', teamSlug)
+    .single();
+
+  if (teamError || !team) {
+    throw new Response('Team not found', { status: 404 });
+  }
+
+  const { data: teamMember, error: memberError } = await supabaseClient
+    .from('team_members')
+    .select('role')
+    .eq('team_id', team.id)
+    .eq('user_id', userId)
+    .single();
+
+  if (memberError || !teamMember) {
+    throw new Response('Access denied: You are not a member of this team', {
+      status: 403,
+    });
+  }
+
+  return team;
+}
+
+export async function loader({
+  request,
+  params,
+}: {
+  request: Request;
+  params: { teamSlug: string };
+}) {
+  const { user, supabaseClient } = await requireAuthWithClient(request);
+
+  try {
+    await ensureUserProfile(user, request);
+  } catch {
+    // Continue even if profile creation fails; access is still checked below.
+  }
+
+  const team = await getTeamForUser(supabaseClient, user.id, params.teamSlug);
+
+  const { data: brands, error } = await supabaseClient
+    .from('brands')
+    .select('*')
+    .eq('team_id', team.id)
+    .order('name', { ascending: true });
+
+  if (error) {
+    throw new Error('Failed to load brands');
+  }
+
+  return { team, brands: brands || [] };
+}
+
+export async function action({
+  request,
+  params,
+}: {
+  request: Request;
+  params: { teamSlug: string };
+}) {
+  const { user, supabaseClient } = await requireAuthWithClient(request);
+  const team = await getTeamForUser(supabaseClient, user.id, params.teamSlug);
+  const formData = await request.formData();
+  const intent = getStringValue(formData, 'intent');
+
+  if (intent === 'create') {
+    const result = getBrandFormValues(formData);
+    if (!result.ok) return { error: result.error };
+
+    const { error } = await supabaseClient.from('brands').insert({
+      ...result.values,
+      team_id: team.id,
+    });
+
+    if (error) return { error: getMutationErrorMessage(error) };
+
+    return redirect(`/${team.slug}/brands`);
+  }
+
+  if (intent === 'update') {
+    const brandId = getStringValue(formData, 'brand_id');
+    const result = getBrandFormValues(formData);
+
+    if (!brandId) return { error: 'Brand id is required.' };
+    if (!result.ok) return { error: result.error };
+
+    const { error } = await supabaseClient
+      .from('brands')
+      .update(result.values)
+      .eq('id', brandId)
+      .eq('team_id', team.id);
+
+    if (error) return { error: getMutationErrorMessage(error) };
+
+    return redirect(`/${team.slug}/brands`);
+  }
+
+  if (intent === 'delete') {
+    const brandId = getStringValue(formData, 'brand_id');
+
+    if (!brandId) return { error: 'Brand id is required.' };
+
+    const { error } = await supabaseClient
+      .from('brands')
+      .delete()
+      .eq('id', brandId)
+      .eq('team_id', team.id);
+
+    if (error) return { error: error.message };
+
+    return redirect(`/${team.slug}/brands`);
+  }
+
+  return { error: 'Invalid action.' };
+}
+
+function BrandLogo({ brand }: { brand: Brand }) {
+  if (brand.logo_url) {
+    return (
+      <img
+        src={brand.logo_url}
+        alt={brand.name}
+        className="h-12 w-12 rounded-md border object-cover"
+      />
+    );
+  }
+
+  return (
+    <div className="h-12 w-12 rounded-md border bg-muted flex items-center justify-center text-muted-foreground">
+      <ImageIcon className="h-5 w-5" />
+    </div>
+  );
+}
+
+export default function BrandsPage() {
+  const { team, brands } = useLoaderData<typeof loader>() as {
+    team: Pick<Team, 'id' | 'name' | 'slug'>;
+    brands: Brand[];
+  };
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state !== 'idle';
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Brands</h1>
+        <p className="text-sm text-muted-foreground">{team.name}</p>
+      </div>
+
+      {actionData?.error && (
+        <div className="rounded-md border border-destructive/30 bg-destructive/10 px-4 py-3 text-sm text-destructive">
+          {actionData.error}
+        </div>
+      )}
+
+      <section className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-md bg-muted">
+            <Plus className="h-5 w-5" />
+          </div>
+          <div>
+            <h2 className="font-semibold">Create brand</h2>
+            <p className="text-sm text-muted-foreground">
+              Add a brand for this team.
+            </p>
+          </div>
+        </div>
+
+        <Form
+          method="post"
+          className="grid gap-4 lg:grid-cols-[1fr_1fr_1fr_auto]"
+        >
+          <input type="hidden" name="intent" value="create" />
+          <div className="space-y-2">
+            <Label htmlFor="create-name">Name</Label>
+            <Input id="create-name" name="name" placeholder="Vio Ljusfabrik" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="create-slug">Slug</Label>
+            <Input id="create-slug" name="slug" placeholder="vio-ljusfabrik" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="create-logo-url">Logo URL</Label>
+            <Input
+              id="create-logo-url"
+              name="logo_url"
+              placeholder="https://example.com/logo.png"
+            />
+          </div>
+          <Button type="submit" disabled={isSubmitting} className="self-end">
+            <Plus className="h-4 w-4" />
+            Create
+          </Button>
+        </Form>
+      </section>
+
+      <div className="flex items-center justify-between">
+        <h2 className="font-semibold">All brands</h2>
+        <span className="text-sm text-muted-foreground">
+          {brands.length} {brands.length === 1 ? 'brand' : 'brands'}
+        </span>
+      </div>
+
+      {brands.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-12 text-center text-muted-foreground">
+          <Building2 className="mx-auto mb-3 h-10 w-10 opacity-60" />
+          <p>No brands yet</p>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          {brands.map(brand => (
+            <Card key={brand.id}>
+              <CardHeader>
+                <div className="flex items-start gap-4">
+                  <BrandLogo brand={brand} />
+                  <div className="min-w-0 flex-1">
+                    <CardTitle className="truncate">{brand.name}</CardTitle>
+                    <CardDescription className="truncate">
+                      /{brand.slug}
+                    </CardDescription>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                <Form method="post" className="space-y-4">
+                  <input type="hidden" name="intent" value="update" />
+                  <input type="hidden" name="brand_id" value={brand.id} />
+
+                  <div className="grid gap-4 md:grid-cols-2">
+                    <div className="space-y-2">
+                      <Label htmlFor={`name-${brand.id}`}>Name</Label>
+                      <Input
+                        id={`name-${brand.id}`}
+                        name="name"
+                        defaultValue={brand.name}
+                      />
+                    </div>
+                    <div className="space-y-2">
+                      <Label htmlFor={`slug-${brand.id}`}>Slug</Label>
+                      <Input
+                        id={`slug-${brand.id}`}
+                        name="slug"
+                        defaultValue={brand.slug}
+                      />
+                    </div>
+                  </div>
+
+                  <div className="space-y-2">
+                    <Label htmlFor={`logo-url-${brand.id}`}>Logo URL</Label>
+                    <Input
+                      id={`logo-url-${brand.id}`}
+                      name="logo_url"
+                      defaultValue={brand.logo_url ?? ''}
+                    />
+                  </div>
+
+                  <Button type="submit" disabled={isSubmitting} size="sm">
+                    <Save className="h-4 w-4" />
+                    Save
+                  </Button>
+                </Form>
+
+                <Form
+                  method="post"
+                  onSubmit={event => {
+                    if (!globalThis.confirm(`Delete ${brand.name}?`)) {
+                      event.preventDefault();
+                    }
+                  }}
+                >
+                  <input type="hidden" name="intent" value="delete" />
+                  <input type="hidden" name="brand_id" value={brand.id} />
+                  <Button
+                    type="submit"
+                    variant="destructive"
+                    size="sm"
+                    disabled={isSubmitting}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                    Delete
+                  </Button>
+                </Form>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/routes/_in.$teamSlug.brands.tsx
+++ b/app/routes/_in.$teamSlug.brands.tsx
@@ -1,5 +1,6 @@
 import {
   Form,
+  Link,
   redirect,
   useActionData,
   useLoaderData,
@@ -25,6 +26,7 @@ import type { Brand, Team } from '~/types/global';
 import type { Database } from '~/types/supabase';
 
 type TypedSupabaseClient = SupabaseClient<Database>;
+const BRANDS_PAGE_SIZE = 6;
 
 interface BrandFormValues {
   name: string;
@@ -50,6 +52,21 @@ function normalizeSlug(value: string) {
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, '-')
     .replace(/^-+|-+$/g, '');
+}
+
+function getPageParam(request: Request) {
+  const url = new URL(request.url);
+  const page = Number(url.searchParams.get('page') || '1');
+
+  if (!Number.isInteger(page) || page < 1) {
+    return 1;
+  }
+
+  return page;
+}
+
+function getBrandsPath(teamSlug: string, page: number) {
+  return page <= 1 ? `/${teamSlug}/brands` : `/${teamSlug}/brands?page=${page}`;
 }
 
 function getBrandFormValues(formData: FormData): BrandFormResult {
@@ -131,18 +148,42 @@ export async function loader({
   }
 
   const team = await getTeamForUser(supabaseClient, user.id, params.teamSlug);
+  const page = getPageParam(request);
+  const from = (page - 1) * BRANDS_PAGE_SIZE;
+  const to = from + BRANDS_PAGE_SIZE - 1;
 
-  const { data: brands, error } = await supabaseClient
+  const {
+    data: brands,
+    error,
+    count,
+  } = await supabaseClient
     .from('brands')
-    .select('*')
+    .select('*', { count: 'exact' })
     .eq('team_id', team.id)
-    .order('name', { ascending: true });
+    .order('created_at', { ascending: false })
+    .range(from, to);
 
   if (error) {
     throw new Error('Failed to load brands');
   }
 
-  return { team, brands: brands || [] };
+  const totalCount = count || 0;
+  const totalPages = Math.max(1, Math.ceil(totalCount / BRANDS_PAGE_SIZE));
+
+  if (page > totalPages && totalCount > 0) {
+    return redirect(getBrandsPath(team.slug, totalPages));
+  }
+
+  return {
+    team,
+    brands: brands || [],
+    pagination: {
+      page,
+      pageSize: BRANDS_PAGE_SIZE,
+      totalCount,
+      totalPages,
+    },
+  };
 }
 
 export async function action({
@@ -154,6 +195,7 @@ export async function action({
 }) {
   const { user, supabaseClient } = await requireAuthWithClient(request);
   const team = await getTeamForUser(supabaseClient, user.id, params.teamSlug);
+  const page = getPageParam(request);
   const formData = await request.formData();
   const intent = getStringValue(formData, 'intent');
 
@@ -186,7 +228,7 @@ export async function action({
 
     if (error) return { error: getMutationErrorMessage(error) };
 
-    return redirect(`/${team.slug}/brands`);
+    return redirect(getBrandsPath(team.slug, page));
   }
 
   if (intent === 'delete') {
@@ -202,7 +244,7 @@ export async function action({
 
     if (error) return { error: error.message };
 
-    return redirect(`/${team.slug}/brands`);
+    return redirect(getBrandsPath(team.slug, page));
   }
 
   return { error: 'Invalid action.' };
@@ -227,13 +269,30 @@ function BrandLogo({ brand }: { brand: Brand }) {
 }
 
 export default function BrandsPage() {
-  const { team, brands } = useLoaderData<typeof loader>() as {
+  const { team, brands, pagination } = useLoaderData<typeof loader>() as {
     team: Pick<Team, 'id' | 'name' | 'slug'>;
     brands: Brand[];
+    pagination: {
+      page: number;
+      pageSize: number;
+      totalCount: number;
+      totalPages: number;
+    };
   };
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const isSubmitting = navigation.state !== 'idle';
+  const createFormKey = pagination.totalCount;
+  const firstBrandNumber =
+    pagination.totalCount === 0
+      ? 0
+      : (pagination.page - 1) * pagination.pageSize + 1;
+  const lastBrandNumber = Math.min(
+    pagination.page * pagination.pageSize,
+    pagination.totalCount
+  );
+  const hasPreviousPage = pagination.page > 1;
+  const hasNextPage = pagination.page < pagination.totalPages;
 
   return (
     <div className="space-y-6">
@@ -262,6 +321,7 @@ export default function BrandsPage() {
         </div>
 
         <Form
+          key={createFormKey}
           method="post"
           className="grid gap-4 lg:grid-cols-[1fr_1fr_1fr_auto]"
         >
@@ -292,7 +352,8 @@ export default function BrandsPage() {
       <div className="flex items-center justify-between">
         <h2 className="font-semibold">All brands</h2>
         <span className="text-sm text-muted-foreground">
-          {brands.length} {brands.length === 1 ? 'brand' : 'brands'}
+          {pagination.totalCount}{' '}
+          {pagination.totalCount === 1 ? 'brand' : 'brands'}
         </span>
       </div>
 
@@ -378,6 +439,44 @@ export default function BrandsPage() {
               </CardContent>
             </Card>
           ))}
+        </div>
+      )}
+
+      {pagination.totalCount > pagination.pageSize && (
+        <div className="flex flex-col gap-3 rounded-lg border bg-card px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-sm text-muted-foreground">
+            Showing {firstBrandNumber}-{lastBrandNumber} of{' '}
+            {pagination.totalCount}
+          </p>
+          <div className="flex items-center gap-2">
+            {hasPreviousPage ? (
+              <Button variant="outline" size="sm" asChild>
+                <Link to={getBrandsPath(team.slug, pagination.page - 1)}>
+                  Previous
+                </Link>
+              </Button>
+            ) : (
+              <Button variant="outline" size="sm" disabled>
+                Previous
+              </Button>
+            )}
+
+            <span className="min-w-20 text-center text-sm text-muted-foreground">
+              Page {pagination.page} of {pagination.totalPages}
+            </span>
+
+            {hasNextPage ? (
+              <Button variant="outline" size="sm" asChild>
+                <Link to={getBrandsPath(team.slug, pagination.page + 1)}>
+                  Next
+                </Link>
+              </Button>
+            ) : (
+              <Button variant="outline" size="sm" disabled>
+                Next
+              </Button>
+            )}
+          </div>
         </div>
       )}
     </div>

--- a/app/routes/_in.$teamSlug.brands.tsx
+++ b/app/routes/_in.$teamSlug.brands.tsx
@@ -18,6 +18,16 @@ import {
   CardHeader,
   CardTitle,
 } from '~/components/ui/card';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '~/components/ui/dialog';
 import { Input } from '~/components/ui/input';
 import { Label } from '~/components/ui/label';
 import { requireAuthWithClient, ensureUserProfile } from '../lib/auth.server';
@@ -416,26 +426,46 @@ export default function BrandsPage() {
                   </Button>
                 </Form>
 
-                <Form
-                  method="post"
-                  onSubmit={event => {
-                    if (!globalThis.confirm(`Delete ${brand.name}?`)) {
-                      event.preventDefault();
-                    }
-                  }}
-                >
-                  <input type="hidden" name="intent" value="delete" />
-                  <input type="hidden" name="brand_id" value={brand.id} />
-                  <Button
-                    type="submit"
-                    variant="destructive"
-                    size="sm"
-                    disabled={isSubmitting}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Delete
-                  </Button>
-                </Form>
+                <Dialog>
+                  <DialogTrigger asChild>
+                    <Button
+                      type="button"
+                      variant="destructive"
+                      size="sm"
+                      disabled={isSubmitting}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                      Delete
+                    </Button>
+                  </DialogTrigger>
+                  <DialogContent>
+                    <DialogHeader>
+                      <DialogTitle>Delete brand</DialogTitle>
+                      <DialogDescription>
+                        Are you sure you want to delete {brand.name}?
+                      </DialogDescription>
+                    </DialogHeader>
+                    <DialogFooter>
+                      <DialogClose asChild>
+                        <Button type="button" variant="outline">
+                          Cancel
+                        </Button>
+                      </DialogClose>
+                      <Form method="post">
+                        <input type="hidden" name="intent" value="delete" />
+                        <input type="hidden" name="brand_id" value={brand.id} />
+                        <Button
+                          type="submit"
+                          variant="destructive"
+                          disabled={isSubmitting}
+                        >
+                          <Trash2 className="h-4 w-4" />
+                          Delete
+                        </Button>
+                      </Form>
+                    </DialogFooter>
+                  </DialogContent>
+                </Dialog>
               </CardContent>
             </Card>
           ))}

--- a/app/routes/_in.$teamSlug.brands.tsx
+++ b/app/routes/_in.$teamSlug.brands.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import {
   Form,
   Link,
@@ -8,7 +9,7 @@ import {
   type MetaFunction,
 } from 'react-router';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { Building2, ImageIcon, Plus, Save, Trash2 } from 'lucide-react';
+import { Building2, ImageIcon, Pencil, Plus, Trash2 } from 'lucide-react';
 
 import { Button } from '~/components/ui/button';
 import {
@@ -278,6 +279,126 @@ function BrandLogo({ brand }: { brand: Brand }) {
   );
 }
 
+interface BrandCardProps {
+  brand: Brand;
+  isSubmitting: boolean;
+}
+
+function BrandCard({ brand, isSubmitting }: BrandCardProps) {
+  const [name, setName] = useState(brand.name);
+  const [slug, setSlug] = useState(brand.slug);
+  const [logoUrl, setLogoUrl] = useState(brand.logo_url ?? '');
+
+  const hasChanges =
+    name !== brand.name ||
+    slug !== brand.slug ||
+    logoUrl !== (brand.logo_url ?? '');
+  const canEdit = name.trim().length > 0 && normalizeSlug(slug).length > 0;
+
+  return (
+    <Card>
+      <CardHeader>
+        <div className="flex items-start gap-4">
+          <BrandLogo brand={brand} />
+          <div className="min-w-0 flex-1">
+            <CardTitle className="truncate">{brand.name}</CardTitle>
+            <CardDescription className="truncate">
+              /{brand.slug}
+            </CardDescription>
+          </div>
+        </div>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Form method="post" className="space-y-4">
+          <input type="hidden" name="intent" value="update" />
+          <input type="hidden" name="brand_id" value={brand.id} />
+
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor={`name-${brand.id}`}>Name</Label>
+              <Input
+                id={`name-${brand.id}`}
+                name="name"
+                value={name}
+                onChange={event => setName(event.target.value)}
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor={`slug-${brand.id}`}>Slug</Label>
+              <Input
+                id={`slug-${brand.id}`}
+                name="slug"
+                value={slug}
+                onChange={event => setSlug(event.target.value)}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor={`logo-url-${brand.id}`}>Logo URL</Label>
+            <Input
+              id={`logo-url-${brand.id}`}
+              name="logo_url"
+              value={logoUrl}
+              onChange={event => setLogoUrl(event.target.value)}
+            />
+          </div>
+
+          <Button
+            type="submit"
+            disabled={isSubmitting || !hasChanges || !canEdit}
+            size="sm"
+          >
+            <Pencil className="h-4 w-4" />
+            Edit
+          </Button>
+        </Form>
+
+        <Dialog>
+          <DialogTrigger asChild>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              disabled={isSubmitting}
+            >
+              <Trash2 className="h-4 w-4" />
+              Delete
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Delete brand</DialogTitle>
+              <DialogDescription>
+                Are you sure you want to delete {brand.name}?
+              </DialogDescription>
+            </DialogHeader>
+            <DialogFooter>
+              <DialogClose asChild>
+                <Button type="button" variant="outline">
+                  Cancel
+                </Button>
+              </DialogClose>
+              <Form method="post">
+                <input type="hidden" name="intent" value="delete" />
+                <input type="hidden" name="brand_id" value={brand.id} />
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  disabled={isSubmitting}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Delete
+                </Button>
+              </Form>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </CardContent>
+    </Card>
+  );
+}
+
 export default function BrandsPage() {
   const { team, brands, pagination } = useLoaderData<typeof loader>() as {
     team: Pick<Team, 'id' | 'name' | 'slug'>;
@@ -375,99 +496,11 @@ export default function BrandsPage() {
       ) : (
         <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
           {brands.map(brand => (
-            <Card key={brand.id}>
-              <CardHeader>
-                <div className="flex items-start gap-4">
-                  <BrandLogo brand={brand} />
-                  <div className="min-w-0 flex-1">
-                    <CardTitle className="truncate">{brand.name}</CardTitle>
-                    <CardDescription className="truncate">
-                      /{brand.slug}
-                    </CardDescription>
-                  </div>
-                </div>
-              </CardHeader>
-              <CardContent className="space-y-4">
-                <Form method="post" className="space-y-4">
-                  <input type="hidden" name="intent" value="update" />
-                  <input type="hidden" name="brand_id" value={brand.id} />
-
-                  <div className="grid gap-4 md:grid-cols-2">
-                    <div className="space-y-2">
-                      <Label htmlFor={`name-${brand.id}`}>Name</Label>
-                      <Input
-                        id={`name-${brand.id}`}
-                        name="name"
-                        defaultValue={brand.name}
-                      />
-                    </div>
-                    <div className="space-y-2">
-                      <Label htmlFor={`slug-${brand.id}`}>Slug</Label>
-                      <Input
-                        id={`slug-${brand.id}`}
-                        name="slug"
-                        defaultValue={brand.slug}
-                      />
-                    </div>
-                  </div>
-
-                  <div className="space-y-2">
-                    <Label htmlFor={`logo-url-${brand.id}`}>Logo URL</Label>
-                    <Input
-                      id={`logo-url-${brand.id}`}
-                      name="logo_url"
-                      defaultValue={brand.logo_url ?? ''}
-                    />
-                  </div>
-
-                  <Button type="submit" disabled={isSubmitting} size="sm">
-                    <Save className="h-4 w-4" />
-                    Save
-                  </Button>
-                </Form>
-
-                <Dialog>
-                  <DialogTrigger asChild>
-                    <Button
-                      type="button"
-                      variant="destructive"
-                      size="sm"
-                      disabled={isSubmitting}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      Delete
-                    </Button>
-                  </DialogTrigger>
-                  <DialogContent>
-                    <DialogHeader>
-                      <DialogTitle>Delete brand</DialogTitle>
-                      <DialogDescription>
-                        Are you sure you want to delete {brand.name}?
-                      </DialogDescription>
-                    </DialogHeader>
-                    <DialogFooter>
-                      <DialogClose asChild>
-                        <Button type="button" variant="outline">
-                          Cancel
-                        </Button>
-                      </DialogClose>
-                      <Form method="post">
-                        <input type="hidden" name="intent" value="delete" />
-                        <input type="hidden" name="brand_id" value={brand.id} />
-                        <Button
-                          type="submit"
-                          variant="destructive"
-                          disabled={isSubmitting}
-                        >
-                          <Trash2 className="h-4 w-4" />
-                          Delete
-                        </Button>
-                      </Form>
-                    </DialogFooter>
-                  </DialogContent>
-                </Dialog>
-              </CardContent>
-            </Card>
+            <BrandCard
+              key={`${brand.id}:${brand.updated_at}`}
+              brand={brand}
+              isSubmitting={isSubmitting}
+            />
           ))}
         </div>
       )}

--- a/app/routes/_in.$teamSlug.templates._index.tsx
+++ b/app/routes/_in.$teamSlug.templates._index.tsx
@@ -1,5 +1,9 @@
-import { useState } from 'react';
-import { useNavigate, useLoaderData, type MetaFunction } from 'react-router';
+import {
+  redirect,
+  useNavigate,
+  useLoaderData,
+  type MetaFunction,
+} from 'react-router';
 import { requireAuthWithClient, ensureUserProfile } from '../lib/auth.server';
 import type { TemplateWithLocales } from '../types/global';
 import {
@@ -9,11 +13,26 @@ import {
 import { appService } from '~/services/app';
 import { Card, CardContent, CardHeader, CardTitle } from '~/components/ui/card';
 import { Badge } from '~/components/ui/badge';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/components/ui/select';
 import { Play, Globe, Clock } from 'lucide-react';
+
+const ALL_BRANDS_VALUE = 'all-brands';
 
 export const meta: MetaFunction = () => {
   return [{ title: `Video Templates - ${appService.strings.app.title}` }];
 };
+
+function getTemplatesPath(teamSlug: string, brandSlug?: string) {
+  return brandSlug
+    ? `/${teamSlug}/templates?brand=${encodeURIComponent(brandSlug)}`
+    : `/${teamSlug}/templates`;
+}
 
 export async function loader({
   request,
@@ -53,9 +72,28 @@ export async function loader({
   if (memberError || !teamMember) {
     throw new Error('Access denied: You are not a member of this team');
   }
+  const url = new URL(request.url);
+  const selectedBrandSlug = url.searchParams.get('brand') || '';
+
+  const { data: brands, error: brandsError } = await supabaseClient
+    .from('brands')
+    .select('id, name, slug')
+    .eq('team_id', team.id)
+    .order('name', { ascending: true });
+
+  if (brandsError) {
+    throw new Error('Failed to load brands');
+  }
+  const selectedBrand = selectedBrandSlug
+    ? brands?.find(brand => brand.slug === selectedBrandSlug)
+    : null;
+
+  if (selectedBrandSlug && !selectedBrand) {
+    return redirect(getTemplatesPath(team.slug));
+  }
 
   // Build query for templates
-  const templatesQuery = supabaseClient
+  let templatesQuery = supabaseClient
     .from('templates')
     .select(
       `
@@ -73,6 +111,10 @@ export async function loader({
     )
     .eq('team_id', team.id);
 
+  if (selectedBrand) {
+    templatesQuery = templatesQuery.eq('brand_id', selectedBrand.id);
+  }
+
   const { data: templates, error } = await templatesQuery.order('created_at', {
     ascending: false,
   });
@@ -81,7 +123,13 @@ export async function loader({
     throw new Error('Failed to load templates');
   }
 
-  return { user, team, templates: templates || [] };
+  return {
+    user,
+    team,
+    brands: brands || [],
+    selectedBrandSlug,
+    templates: templates || [],
+  };
 }
 
 // Helper function to get template status based on locales
@@ -92,7 +140,7 @@ function getTemplateStatus(
   if (locales.length === 0) return 'draft';
   if (
     locales.some(
-      (locale: { last_render_url?: string }) => locale.last_render_url
+      (locale: { last_render_url: string | null }) => locale.last_render_url
     )
   )
     return 'completed';
@@ -121,12 +169,10 @@ function formatTemplateDuration(template: TemplateWithLocales) {
 
 export default function TemplatesPage() {
   const navigate = useNavigate();
-  const { user, team, templates } = useLoaderData<typeof loader>();
-  const [searchQuery] = useState('');
+  const { user, team, templates, brands, selectedBrandSlug } =
+    useLoaderData<typeof loader>();
 
-  const filteredTemplates = templates.filter(template =>
-    template.title.toLowerCase().includes(searchQuery.toLowerCase())
-  );
+  const filteredTemplates = templates;
 
   const getStatusColor = (status: 'completed' | 'in-progress' | 'draft') => {
     switch (status) {
@@ -153,8 +199,44 @@ export default function TemplatesPage() {
       navigate(`/${team.slug}/templates/${templateId}/en/edit`);
     }
   };
+
+  const handleBrandChange = (value: string) => {
+    if (value === ALL_BRANDS_VALUE) {
+      navigate(getTemplatesPath(team.slug));
+      return;
+    }
+
+    navigate(getTemplatesPath(team.slug, value));
+  };
+
   return (
     <div className="space-y-6">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">
+            Video Templates
+          </h1>
+          <p className="text-sm text-muted-foreground">{team.name}</p>
+        </div>
+
+        <Select
+          value={selectedBrandSlug || ALL_BRANDS_VALUE}
+          onValueChange={handleBrandChange}
+        >
+          <SelectTrigger className="w-full sm:w-64">
+            <SelectValue placeholder="Brand" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value={ALL_BRANDS_VALUE}>All brands</SelectItem>
+            {brands.map(brand => (
+              <SelectItem key={brand.id} value={brand.slug}>
+                {brand.name}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+      </div>
+
       {/* Templates Grid */}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
         {filteredTemplates.map((template, index) => (
@@ -244,7 +326,7 @@ export default function TemplatesPage() {
           <div className="text-muted-foreground">
             <Globe className="h-12 w-12 mx-auto mb-4 opacity-50 animate-pulse" />
             <p className="text-lg mb-2">No templates found</p>
-            <p>Try adjusting your search or create a new template</p>
+            <p>Try selecting another brand or create a new template</p>
           </div>
         </div>
       )}

--- a/app/routes/_in.$teamSlug.tsx
+++ b/app/routes/_in.$teamSlug.tsx
@@ -21,11 +21,11 @@ export default function InLayout() {
       <Sidebar currentPath={currentPath} />
 
       {/* Main Content */}
-      <div className="flex-1 flex flex-col overflow-hidden">
-        <TopBar />
+      <div className="min-w-0 flex-1 flex flex-col overflow-hidden">
+        <TopBar currentPath={currentPath} />
 
         {/* Dynamic Content Area */}
-        <main className="flex-1 p-6 overflow-y-auto">
+        <main className="flex-1 p-4 md:p-6 overflow-y-auto">
           <Outlet />
         </main>
       </div>

--- a/app/types/global.ts
+++ b/app/types/global.ts
@@ -3,6 +3,7 @@ import type { Database } from './supabase';
 type Tables = Database['public']['Tables'];
 
 export type Profile = Tables['user_profiles']['Row'];
+export type Brand = Tables['brands']['Row'];
 export type Template = Tables['templates']['Row'];
 export type TemplateLocale = Tables['template_locales']['Row'];
 export type Team = Tables['teams']['Row'];
@@ -18,6 +19,10 @@ export interface TeamWithMembers extends Team {
 
 export interface TemplateWithTeam extends Template {
   team?: Team;
+}
+
+export interface TemplateWithBrand extends Template {
+  brand?: Brand;
 }
 
 export type TeamRole = TeamMember['role'];

--- a/app/types/supabase.d.ts
+++ b/app/types/supabase.d.ts
@@ -9,6 +9,44 @@ export type Json =
 export type Database = {
   public: {
     Tables: {
+      brands: {
+        Row: {
+          created_at: string;
+          id: string;
+          logo_url: string | null;
+          name: string;
+          slug: string;
+          team_id: string;
+          updated_at: string;
+        };
+        Insert: {
+          created_at?: string;
+          id?: string;
+          logo_url?: string | null;
+          name: string;
+          slug: string;
+          team_id: string;
+          updated_at?: string;
+        };
+        Update: {
+          created_at?: string;
+          id?: string;
+          logo_url?: string | null;
+          name?: string;
+          slug?: string;
+          team_id?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: 'brands_team_id_fkey';
+            columns: ['team_id'];
+            isOneToOne: false;
+            referencedRelation: 'teams';
+            referencedColumns: ['id'];
+          },
+        ];
+      };
       team_members: {
         Row: {
           id: string;
@@ -126,6 +164,7 @@ export type Database = {
       };
       templates: {
         Row: {
+          brand_id: string | null;
           created_at: string;
           creator_user_id: string | null;
           description: string | null;
@@ -137,6 +176,7 @@ export type Database = {
           updated_at: string;
         };
         Insert: {
+          brand_id?: string | null;
           created_at?: string;
           creator_user_id?: string | null;
           description?: string | null;
@@ -148,6 +188,7 @@ export type Database = {
           updated_at?: string;
         };
         Update: {
+          brand_id?: string | null;
           created_at?: string;
           creator_user_id?: string | null;
           description?: string | null;
@@ -159,6 +200,13 @@ export type Database = {
           updated_at?: string;
         };
         Relationships: [
+          {
+            foreignKeyName: 'templates_brand_id_fkey';
+            columns: ['brand_id'];
+            isOneToOne: false;
+            referencedRelation: 'brands';
+            referencedColumns: ['id'];
+          },
           {
             foreignKeyName: 'templates_creator_user_id_fkey';
             columns: ['creator_user_id'];

--- a/supabase/migrations/20260521120000_add_brands.sql
+++ b/supabase/migrations/20260521120000_add_brands.sql
@@ -1,0 +1,71 @@
+-- Brands Table
+create table public.brands (
+  id uuid primary key default uuid_generate_v4(),
+  team_id uuid not null references public.teams(id) on delete cascade,
+  name text not null,
+  slug text not null,
+  logo_url text,
+  created_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
+  unique(team_id, slug)
+);
+
+alter table public.templates
+add column brand_id uuid references public.brands(id) on delete set null;
+
+-- Brands indexes
+create index brands_team_id_idx on public.brands(team_id);
+create index brands_slug_idx on public.brands(slug);
+
+-- Templates brand index
+create index templates_brand_id_idx on public.templates(brand_id);
+
+-- Enable Row Level Security
+alter table public.brands enable row level security;
+
+-- Brands Policies
+create policy "Users can view brands of their teams"
+  on public.brands for select
+  using (
+    exists (
+      select 1 from public.team_members
+      where team_members.team_id = brands.team_id
+      and team_members.user_id = auth.uid()
+    )
+  );
+
+create policy "Team members can insert brands"
+  on public.brands for insert
+  with check (
+    exists (
+      select 1 from public.team_members
+      where team_members.team_id = brands.team_id
+      and team_members.user_id = auth.uid()
+    )
+  );
+
+create policy "Team members can update brands"
+  on public.brands for update
+  using (
+    exists (
+      select 1 from public.team_members
+      where team_members.team_id = brands.team_id
+      and team_members.user_id = auth.uid()
+    )
+  );
+
+create policy "Team members can delete brands"
+  on public.brands for delete
+  using (
+    exists (
+      select 1 from public.team_members
+      where team_members.team_id = brands.team_id
+      and team_members.user_id = auth.uid()
+    )
+  );
+
+-- Create trigger for updated_at
+create trigger set_updated_at
+  before update on public.brands
+  for each row
+  execute function public.handle_updated_at();

--- a/supabase/seed/main.sql
+++ b/supabase/seed/main.sql
@@ -29,6 +29,17 @@ INSERT INTO public.templates
 VALUES 
   ('550e8400-e29b-41d4-a716-446655440001', 'Video Template 1', 'Example product video', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', '813b6b64-f5f4-49ea-9719-c49db026d937', '/video_placeholder.svg', 12110, NOW(), NOW());
 
+-- Brands
+INSERT INTO public.brands
+  (id, team_id, name, slug, logo_url, created_at, updated_at)
+VALUES
+  ('770e8400-e29b-41d4-a716-446655440001', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', 'Vio Ljusfabrik', 'vio-ljusfabrik', NULL, NOW(), NOW()),
+  ('770e8400-e29b-41d4-a716-446655440002', '5e44edd3-df5d-4ff1-84f4-0ca7d7ba1704', 'Nordic Coffee', 'nordic-coffee', NULL, NOW(), NOW());
+
+UPDATE public.templates
+SET brand_id = '770e8400-e29b-41d4-a716-446655440001'
+WHERE id = '550e8400-e29b-41d4-a716-446655440001';
+
 -- template locales
 INSERT INTO public.template_locales
   (id, template_id, locale, last_render_url, thumbnail_url, created_at, updated_at)


### PR DESCRIPTION
- Added a Brands CRUD page at `/:teamSlug/brands`
- Added the `brands` database model and connected templates to brands
- Added seed data for example brands
- Added a brand selector on the templates page with `?brand=` URL filtering
- Improved the brands page with pagination, newest-first sorting, edit validation, and delete confirmation dialog
- Made the app navigation responsive with a mobile menu

<img width="1755" height="916" alt="image" src="https://github.com/user-attachments/assets/360b1243-2941-4cc6-b042-c23979370f12" />

<img width="2459" height="351" alt="image" src="https://github.com/user-attachments/assets/aba65113-11c3-4921-9157-07683caf05e0" />

<img width="1649" height="1041" alt="image" src="https://github.com/user-attachments/assets/094d44d2-6315-4c88-ba04-637cea29192d" />


<img width="959" height="1067" alt="image" src="https://github.com/user-attachments/assets/16782513-dc76-4950-8613-344622146638" />

<img width="730" height="762" alt="image" src="https://github.com/user-attachments/assets/19e507a8-848a-4816-9eac-8d155453fbe1" />
